### PR TITLE
move rabinsig to dependencies, fixed not found issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "homepage": "https://github.com/sCrypt-Inc/scrypt-ts-lib#readme",
   "dependencies": {
-    "scrypt-ts": "^1.3.2"
+    "scrypt-ts": "^1.3.2",
+    "rabinsig": "^4.2.1"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",
@@ -62,7 +63,6 @@
     "lint-staged": "^13.1.0",
     "mocha": "^10.2.0",
     "prettier": "^2.8.2",
-    "rabinsig": "^4.2.1",
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"


### PR DESCRIPTION
In project env, if rabinsig in devDeps, it will show not found error, so, we move it to dependencied